### PR TITLE
Remove code to create new deployment after updating the app spec

### DIFF
--- a/main.go
+++ b/main.go
@@ -128,12 +128,6 @@ func (a *action) run() error {
 		return errors.Wrap(err, "updating app spec")
 	}
 
-	//creates a new deployment from the updated app spec
-	err = a.client.CreateDeployments(appID)
-	if err != nil {
-		return errors.Wrap(err, "creating new deployment")
-	}
-
 	//checks for deployment status
 	err = a.client.IsDeployed(appID)
 	if err != nil {

--- a/main_test.go
+++ b/main_test.go
@@ -199,7 +199,7 @@ func Test_run(t *testing.T) {
 	}
 	do.EXPECT().RetrieveActiveDeployment(gomock.Eq(activeDeploymentID), gomock.Eq(appID), gomock.Eq(sampleImages)).Return(sampleImagesRepo, deployments[0].Spec, nil)
 	do.EXPECT().UpdateAppPlatformAppSpec(gomock.Any(), appID).Return(nil)
-	do.EXPECT().CreateDeployments(appID).Return(nil)
+
 	do.EXPECT().IsDeployed(appID).Return(nil)
 
 	a := &action{


### PR DESCRIPTION
A second deployment was being created triggering two builds.
