### PR TITLE
Make Golang version in go.mod file explicit

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -14,7 +14,7 @@ on:
     - main
     - go_attempt
 env:
-  GO_VERSION_TO_USE: '^1.22.0'  # The Go version to download (if necessary) and use.
+  GO_VERSION_TO_USE: '1.22.5'  # The Go version to download (if necessary) and use.
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   # The "build" workflow

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/digitalocean/app_action
 
-go 1.22
+go 1.22.5
 
 require (
 	github.com/digitalocean/godo v1.119.0


### PR DESCRIPTION
As per Golang 1.22, go.mod must use the 1.N.P notation. CodeQL is barking at us for not using it currently.