### PR TITLE
Update all source versions when updating the app

### DIFF
--- a/deploy/main.go
+++ b/deploy/main.go
@@ -120,7 +120,7 @@ func (d *deployer) deploy(ctx context.Context, spec *godo.AppSpec) (*godo.App, e
 		}
 	} else {
 		d.action.Infof("app %q already exists, updating...", spec.Name)
-		app, _, err = d.apps.Update(ctx, app.GetID(), &godo.AppUpdateRequest{Spec: spec})
+		app, _, err = d.apps.Update(ctx, app.GetID(), &godo.AppUpdateRequest{Spec: spec, UpdateAllSourceVersions: true})
 		if err != nil {
 			return nil, fmt.Errorf("failed to update app: %w", err)
 		}


### PR DESCRIPTION
Currently, when an app is updated, sources that existed in the app before are **not** updated automatically. This behavior is desired to avoid an app spec change that only changes, for example the scale of a component from picking up new code.

By setting the `UpdateAllSourceVersions` flag, the action now forces updates to **all** the sources of the app (either git based or image based) on the update.

Fixes #123