### PR TITLE
Add the possibility to provide a project ID for the respective app

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ If you require assistance or have a feature idea, please create a support ticket
 
 - `token`: DigitalOcean Personal Access Token. See https://docs.digitalocean.com/reference/api/create-personal-access-token/ for creating a new token.
 - `app_spec_location`: Location of the app spec file. Defaults to `.do/app.yaml`.
+- `project_id`: ID of the project to deploy the app to. If not given, the app will be deployed to the default project.
 - `app_name`: Name of the app to pull the spec from. The app must already exist. If an app name is given, a potential in-repository app spec is ignored.
 - `print_build_logs`: Print build logs. Defaults to `false`.
 - `print_deploy_logs`: Print deploy logs. Defaults to `false`.

--- a/deploy/action.yml
+++ b/deploy/action.yml
@@ -12,6 +12,10 @@ inputs:
     description: Location of the app spec file. Mutually exclusive with `app_name`.
     required: false
     default: '.do/app.yaml'
+  project_id:
+    description: ID of the project to deploy the app to. If not given, the app will be deployed to the default project.
+    required: false
+    default: ''
   app_name:
     description: Name of the app to pull the spec from. The app must already exist. If an app name is given, a potential in-repository app spec is ignored.
     required: false

--- a/deploy/inputs.go
+++ b/deploy/inputs.go
@@ -9,6 +9,7 @@ import (
 type inputs struct {
 	token           string
 	appSpecLocation string
+	projectID       string
 	appName         string
 	printBuildLogs  bool
 	printDeployLogs bool
@@ -21,6 +22,7 @@ func getInputs(a *gha.Action) (inputs, error) {
 	for _, err := range []error{
 		utils.InputAsString(a, "token", true, &in.token),
 		utils.InputAsString(a, "app_spec_location", false, &in.appSpecLocation),
+		utils.InputAsString(a, "project_id", false, &in.projectID),
 		utils.InputAsString(a, "app_name", false, &in.appName),
 		utils.InputAsBool(a, "print_build_logs", true, &in.printBuildLogs),
 		utils.InputAsBool(a, "print_deploy_logs", true, &in.printDeployLogs),

--- a/deploy/main.go
+++ b/deploy/main.go
@@ -114,7 +114,7 @@ func (d *deployer) deploy(ctx context.Context, spec *godo.AppSpec) (*godo.App, e
 	}
 	if app == nil {
 		d.action.Infof("app %q does not exist yet, creating...", spec.Name)
-		app, _, err = d.apps.Create(ctx, &godo.AppCreateRequest{Spec: spec})
+		app, _, err = d.apps.Create(ctx, &godo.AppCreateRequest{Spec: spec, ProjectID: d.inputs.projectID})
 		if err != nil {
 			return nil, fmt.Errorf("failed to create app: %w", err)
 		}


### PR DESCRIPTION
This provides the possibility to provide a project ID when running the action. If the app doesn't exist yet, it will be created in the respective project to ease management of apps.