### PR TITLE
Add explicit permissions blocks to our examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,9 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   deploy-app:
     runs-on: ubuntu-latest
@@ -111,13 +114,13 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   build-push-deploy-image:
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
-      id-token: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -167,6 +170,7 @@ on:
     branches: [main]
 
 permissions:
+  contents: read
   pull-requests: write
 
 jobs:


### PR DESCRIPTION
This adds explicit permission blocks to make the examples work out of the box, even in private repositories.