### PR TITLE
Extract PR number from event instead of using RefName

### DIFF
--- a/delete/main.go
+++ b/delete/main.go
@@ -37,7 +37,11 @@ func main() {
 		appName := in.appName
 		if appName == "" {
 			repoOwner, repo := ghCtx.Repo()
-			appName = utils.GenerateAppName(repoOwner, repo, ghCtx.RefName)
+			prRef, err := utils.PRRefFromContext(ghCtx)
+			if err != nil {
+				a.Fatalf("failed to get PR number: %v", err)
+			}
+			appName = utils.GenerateAppName(repoOwner, repo, prRef)
 		}
 
 		app, err := utils.FindAppByName(ctx, do.Apps, appName)

--- a/utils/preview_test.go
+++ b/utils/preview_test.go
@@ -56,8 +56,12 @@ func TestSanitizeSpecForPullRequestPreview(t *testing.T) {
 
 	ghCtx := &gha.GitHubContext{
 		Repository: "foo/bar",
-		RefName:    "3/merge",
 		HeadRef:    "feature-branch",
+		Event: map[string]any{
+			"pull_request": map[string]any{
+				"number": float64(3),
+			},
+		},
 	}
 
 	err := SanitizeSpecForPullRequestPreview(spec, ghCtx)


### PR DESCRIPTION
On normal pull-request events, the `RefName` attribute is usually `$prNumber/merge`. However, when **merging** a pull-request, it becomes the name of the branch the PR is merged into. This beraks the connection between creating and deleting preview apps.

This changes the method of figuring out the underlying pull-request by looking at the event payload directly and parsing the respective number out of there.