### PR TITLE
Use `APP_ID` instead of the non-existing `APP_NAME`

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ The following action deploys the app whenever a new commit is pushed to the main
 
 In this case, a secret of the repository named `SOME_SECRET_FROM_REPOSITORY` will also be passed into the app via its environment variables as `SOME_SECRET`. It is passed to the action's environment via the `${{ secrets.KEY }}` notation and then substituted into the spec itself via the environment variable reference in `value`. Make sure to define the respective env var's type as `SECRET` in the spec to ensure the value is stored in an encrypted way.
 
-**Note:** `APP_DOMAIN`, `APP_URL` and `APP_NAME` are predefined [App-wide variables](https://docs.digitalocean.com/products/app-platform/how-to/use-environment-variables/#app-wide-variables). Avoid overriding them in the action's environment to avoid the env-var-expansion process of the Github Action to interfere with that of the platform itself.
+**Note:** `APP_DOMAIN`, `APP_URL` and `APP_ID` are predefined [App-wide variables](https://docs.digitalocean.com/products/app-platform/how-to/use-environment-variables/#app-wide-variables). Avoid overriding them in the action's environment to avoid the env-var-expansion process of the Github Action to interfere with that of the platform itself.
 
 ```yaml
 name: Update App

--- a/utils/env.go
+++ b/utils/env.go
@@ -11,7 +11,7 @@ import (
 var appWideVariables = map[string]struct{}{
 	"APP_DOMAIN": {},
 	"APP_URL":    {},
-	"APP_NAME":   {},
+	"APP_ID":   {},
 }
 
 // ExpandEnvRetainingBindables expands the environment variables in s, but it

--- a/utils/env_test.go
+++ b/utils/env_test.go
@@ -39,3 +39,30 @@ func TestExpandEnvRetainingBindables(t *testing.T) {
 		})
 	}
 }
+
+func TestExpandEnvRetainingBindablesAppWideVariables(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		out  string
+	}{{
+		name: "APP_DOMAIN",
+		in:   "${APP_DOMAIN}",
+		out:  "${APP_DOMAIN}",
+	}, {
+		name: "APP_URL",
+		in:   "${APP_URL}",
+		out:  "${APP_URL}",
+	}, {
+		name: "APP_ID",
+		in:   "${APP_ID}",
+		out:  "${APP_ID}",
+	}}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := ExpandEnvRetainingBindables(test.in)
+			require.Equal(t, test.out, got)
+		})
+	}
+}


### PR DESCRIPTION
Looks like the action is referencing a non-existing app-wide variable named `APP_NAME`.

Reading the [app-wide variables](https://docs.digitalocean.com/products/app-platform/how-to/use-environment-variables/#app-wide-variables) section in the docs, the available app-wide variables are:

- `APP_DOMAIN`
- `APP_URL`
- `APP_ID`

Since the action correctly references `APP_DOMAIN` and `APP_URL`, and since there's no reference to `APP_NAME` anywhere in the docs, I'm assuming a typo resulted in `APP_NAME` instead of `APP_ID`.

In addition to the fix, I added a test that makes sure that all the supported app-wide variables are handled correctly.