### PR TITLE
Strip dots from generate app names

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ If you require assistance or have a feature idea, please create a support ticket
 - `token`: DigitalOcean Personal Access Token. See https://docs.digitalocean.com/reference/api/create-personal-access-token/ for creating a new token.
 - `app_id`: ID of the app to delete.
 - `app_name`: Name of the app to delete.
-- `from_pr_preview`: Use this if the app was deployed as a PR preview. The app name will be derived from the PR and.
+- `from_pr_preview`: Use this if the app was deployed as a PR preview. The app name will be derived from a combination of the repo name and the PR.
 - `ignore_not_found`: Ignore if the app is not found.
 
 ## Usage

--- a/utils/preview.go
+++ b/utils/preview.go
@@ -59,6 +59,7 @@ func GenerateAppName(repoOwner, repo, ref string) string {
 		"/", "-", // Replace slashes.
 		":", "", // Colons are illegal.
 		"_", "-", // Underscores are illegal.
+		".", "-", // Dots are illegal.
 	).Replace(baseName)
 
 	// Generate a hash from the unique enumeration of repoOwner, repo, and ref.

--- a/utils/preview_test.go
+++ b/utils/preview_test.go
@@ -139,6 +139,12 @@ func TestGenerateAppName(t *testing.T) {
 		repo:      "thisisanextremelylongreponame",
 		ref:       "3/merge",
 		expected:  "foo-thisisanextremelylo-67dbc40d",
+	}, {
+		name:      "repo with hostname",
+		repoOwner: "foo",
+		repo:      "my.domain.com",
+		ref:       "3/merge",
+		expected:  "foo-my-domain-com-3-mer-b5e0d686",
 	}}
 
 	for _, test := range tests {


### PR DESCRIPTION
Dots are not allowed to be used in app names and so this strips them automatically when we're generating names from repo names for example.