### PR TITLE
Optimize built image by using a multi-stage build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24.0-alpine
+FROM golang:1.24.0-alpine AS build
 
 WORKDIR /usr/src/app
 
@@ -8,3 +8,8 @@ RUN go mod download && go mod verify
 COPY . .
 RUN go build -o /usr/local/bin/deploy ./deploy && \
     go build -o /usr/local/bin/delete ./delete
+
+FROM cgr.dev/chainguard/static:latest
+
+COPY --from=build /usr/local/bin/deploy /usr/local/bin/deploy
+COPY --from=build /usr/local/bin/delete /usr/local/bin/delete


### PR DESCRIPTION
The final binaries don't need the Golang build environment, so this puts them into a distroless image to minimize the resulting image size.