### PR TITLE
APPS-10746: adding a mention of how to use a GHCR registry credential with app deploy step

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ services:
     registry_type: GHCR
     registry: YOUR_ORG
     repository: YOUR_REPO
+    registry_credentials: ${GHCR_CREDENTIALS}
     digest: ${SAMPLE_DIGEST}
 ```
 
@@ -143,6 +144,7 @@ jobs:
         uses: digitalocean/app_action/deploy@v2
         env:
           SAMPLE_DIGEST: ${{ steps.push.outputs.digest }}
+          GHCR_CREDENTIALS: ${{ secrets.GHCR_CREDENTIALS }}
         with:
           token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
 ```


### PR DESCRIPTION
As per title, doing it for [APPS-10746](https://do-internal.atlassian.net/browse/APPS-10746) and based on a customer report [here](https://digitalocean.slack.com/archives/C016LFAP4SE/p1742892524333369)

[APPS-10746]: https://do-internal.atlassian.net/browse/APPS-10746?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ